### PR TITLE
fix 渲染“##”报错的问题

### DIFF
--- a/wemark/wemark.js
+++ b/wemark/wemark.js
@@ -54,7 +54,7 @@ function parse(md, page, options){
 				}
 			}
 		}else{
-			inlineToken.children.forEach(function(token, index){
+			inlineToken.children && inlineToken.children.forEach(function(token, index){
 				if(['text', 'code'].indexOf(token.type) > -1){
 					ret.push({
 						type: env || token.type,


### PR DESCRIPTION
如果渲染的字符串是 '#' 这种报错了，应该是加个判断就好了。因为如果是用这个组件去做输入markdown预览内容会经常遇到的

<img width="634" alt="error" src="https://user-images.githubusercontent.com/20512530/40276604-f307be42-5c40-11e8-9e65-0ebb0d2f0fc2.png">

