### PR TITLE
修复 HTML 高亮语法无法正确解析

### DIFF
--- a/wemark/parser.js
+++ b/wemark/parser.js
@@ -137,11 +137,7 @@ function parse(md, options){
 						tokensArr.forEach(el => {
 							if (typeof el === 'object') {
 								el.type = parentType + ' wemark_inline_code_' + el.type
-								if (el.content.constructor === Array) {
-									flattenTokens(el.content, result, el.type)
-								} else {
-									result.push(el)
-								}
+								flattenTokens(el.content, result, el.type)
 							} else {
 								const obj = {}
 								obj.type = parentType + ' wemark_inline_code_'

--- a/wemark/parser.js
+++ b/wemark/parser.js
@@ -129,6 +129,35 @@ function parse(md, options){
 				content = prism.tokenize(content, prism.languages[blockToken.params]);
 				highlight = true;
 			}
+
+			// flatten nested tokens in html
+			if (blockToken.params === 'html') {
+				const flattenTokens = (tokensArr, result = [], parentType = '') => {
+					if (tokensArr.constructor === Array) {
+						tokensArr.forEach(el => {
+							if (typeof el === 'object') {
+								el.type = parentType + ' wemark_inline_code_' + el.type
+								if (el.content.constructor === Array) {
+									flattenTokens(el.content, result, el.type)
+								} else {
+									result.push(el)
+								}
+							} else {
+								const obj = {}
+								obj.type = parentType + ' wemark_inline_code_'
+								obj.content = el
+								result.push(obj)
+							}
+						})
+						return result
+					} else {
+						result.push(tokensArr)
+						return result
+					}
+				}
+				content = flattenTokens(content)
+			}
+
 			return {
 				type: 'code',
 				highlight: highlight,


### PR DESCRIPTION
使用过程中发现 prism 的 html 会被解析成嵌套的 tokens 数组：
![](https://ws4.sinaimg.cn/large/0069RVTdgy1fu045r7lxtj31500cmgnt.jpg)

目前解决方案是将数组扁平化，子 token 继承父 token 的 type 达到样式继承。

暂时没有加 test。因为看了一下 test，好像没有单独设置 `hightlight` 属性，要加也挺麻烦的。

（另外建议 `.gitignore` 加上 `node_modules`？）